### PR TITLE
Update CI workflow to use Django test runner

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
+        pip install flake8
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
@@ -34,6 +34,6 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
+    - name: Test with Django test suite
       run: |
-        pytest
+        python manage.py test


### PR DESCRIPTION
## Summary
- update the GitHub Actions workflow to install only flake8 before installing project requirements
- switch the test step to run the Django test suite via `python manage.py test`

## Testing
- python manage.py test *(fails: NoReverseMatch for 'booking')*

------
https://chatgpt.com/codex/tasks/task_e_68cc9a1324348329a9c93e9113b43248