### PR TITLE
Rename Django test case for pytest discovery

### DIFF
--- a/app/tests.py
+++ b/app/tests.py
@@ -6,7 +6,7 @@ from django.core.management import call_command
 from io import StringIO
 import os
 
-class RestaurantTableBookingTestCase(TestCase):
+class TestRestaurantTableBooking(TestCase):
     def setUp(self):
         try:
             self.booking_url = reverse('booking')


### PR DESCRIPTION
## Summary
- rename the Django test case class so pytest will detect it during collection

## Testing
- python manage.py test *(fails: booking URL reverse errors)*
- pytest *(no tests collected / Django not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68cc9f472d048329adea85757cf65ea9